### PR TITLE
perf: Fetch version information in parallel

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -5,6 +5,8 @@ set -euo pipefail
 TOOL_NAME="spark"
 TOOL_TEST="spark-shell --version"
 
+CONCURRENCY=32
+
 export CURRENT_DOWNLOADS_URL="https://downloads.apache.org/spark/"
 export ARCHIVE_URL="https://archive.apache.org/dist/spark/"
 
@@ -18,7 +20,7 @@ list_versions() {
 	curl -s "$url" |
 		grep -o "spark-.*" |
 		cut -d '/' -f1 |
-		xargs -I{} curl -s "${url}{}/" |
+		xargs -P$CONCURRENCY -I{} curl -s "${url}{}/" |
 		grep -o ">spark-.*\.tgz</a" |
 		sed 's/>spark-//' |
 		sed 's/\.tgz<\/a//'


### PR DESCRIPTION
list-all is extremely slow and often times out.
We can fetch version information in parallel to speed up the process.

A concurrency of 32 is chosen as a practical default for modern systems.

    # 1
    real    1m23.599s
    user    0m1.220s
    sys     0m1.182s

    # 8
    real    0m11.975s
    user    0m1.026s
    sys     0m0.882s

    # 16
    real    0m7.131s
    user    0m0.887s
    sys     0m0.820s

    # 32
    real    0m4.484s
    user    0m0.798s
    sys     0m0.806s

    # 64
    real    0m2.917s
    user    0m0.653s
    sys     0m0.775s

    # 128
    real    0m2.288s
    user    0m0.598s
    sys     0m0.811s